### PR TITLE
Conjugation of g pulses in nlin.Xhkm_time_integral

### DIFF
--- a/pynlin/nlin.py
+++ b/pynlin/nlin.py
@@ -300,8 +300,7 @@ def Xhkm_time_integral(
         g3 = apply_chromatic_dispersion(pulse, fiber, L, delay=k * T + beta2 * O * L)
         g4 = apply_chromatic_dispersion(pulse, fiber, L, delay=m * T + beta2 * O * L)
 
-        integrand = np.conj(g1) * np.conj(g2) * np.conj(g3) * np.conj(g4)
-
+        integrand = np.conj(g1) * g2 * np.conj(g3) * g4
         time_integrals[i] = scipy.integrate.trapezoid(integrand, t)
 
     return time_integrals

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -81,7 +81,7 @@ wdm.plot(ax, xaxis="frequency")
 
 # compute the collisions between the two furthest WDM channels
 frequency_of_interest = wdm.frequency_grid()[0]
-interfering_frequency = wdm.frequency_grid()[50]
+interfering_frequency = wdm.frequency_grid()[2]
 channel_spacing = interfering_frequency - frequency_of_interest
 
 # pynlin.nlin.X0mm_time_integral_WDM_grid(


### PR DESCRIPTION
Probably in **nlin.Xhkm_time_integral** there was a typo on the conjugation. 
Running with new conjugation reduces the difference between computed and analytical X0mm, _independently_ from the m-index.

In **main** there was an index out of bound issue, I substituted a small channel separation to test the computations on a local machine.
